### PR TITLE
chore(deps): bump rustix to 1.x, rand to 0.9, sha2 to 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,6 +246,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +381,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,6 +397,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -418,6 +442,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -464,8 +497,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -1216,7 +1260,7 @@ dependencies = [
  "itoa",
  "libc",
  "memmap2",
- "rustix 1.1.4",
+ "rustix",
  "smallvec",
  "thiserror",
 ]
@@ -1393,7 +1437,7 @@ dependencies = [
  "gix-command",
  "gix-config-value",
  "parking_lot",
- "rustix 1.1.4",
+ "rustix",
  "thiserror",
 ]
 
@@ -1726,7 +1770,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand 0.9.3",
+ "rand",
  "smallvec",
  "spinning_top",
  "web-time",
@@ -1896,6 +1940,15 @@ name = "human_format"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaec953f16e5bcf6b8a3cb3aa959b17e5577dbd2693e94554c462c08be22624b"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2243,12 +2296,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2634,7 +2681,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.3",
+ "rand",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2683,33 +2730,12 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -2719,16 +2745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
+ "rand_core",
 ]
 
 [[package]]
@@ -2848,7 +2865,7 @@ dependencies = [
  "reposix-sim",
  "reqwest",
  "rusqlite",
- "rustix 0.38.44",
+ "rustix",
  "serde",
  "serde_json",
  "tempfile",
@@ -2865,6 +2882,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "chrono",
+ "hex",
  "parking_lot",
  "pulldown-cmark",
  "reposix-core",
@@ -2927,6 +2945,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "chrono",
+ "hex",
  "parking_lot",
  "reposix-core",
  "reposix-sim",
@@ -3006,7 +3025,7 @@ dependencies = [
  "clap",
  "hdrhistogram",
  "parking_lot",
- "rand 0.8.5",
+ "rand",
  "reposix-confluence",
  "reposix-core",
  "reposix-sim",
@@ -3095,19 +3114,6 @@ checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3115,7 +3121,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -3282,8 +3288,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3292,19 +3298,19 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "sha1",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -3455,7 +3461,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -3764,9 +3770,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uluru"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,8 @@ parking_lot = "0.12"
 dashmap = "6"
 governor = "0.10"  # rate limiting
 pulldown-cmark = "0.13"
-sha2 = "0.10"
+sha2 = "0.11"
+hex = "0.4"
 
 # Internal
 reposix-core = { path = "crates/reposix-core" }

--- a/crates/reposix-cli/Cargo.toml
+++ b/crates/reposix-cli/Cargo.toml
@@ -37,7 +37,7 @@ rusqlite = { workspace = true, features = ["bundled"] }
 tempfile = "3"
 # Safe wrappers for POSIX signals + process syscalls (SIGTERM to child,
 # setsid). Keeps #![forbid(unsafe_code)] at crate root.
-rustix = { version = "0.38", features = ["process"] }
+rustix = { version = "1", features = ["process"] }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/crates/reposix-cli/src/init.rs
+++ b/crates/reposix-cli/src/init.rs
@@ -201,6 +201,10 @@ pub fn run(spec: String, path: PathBuf) -> Result<()> {
 mod tests {
     use super::*;
 
+    // Tests that mutate process-wide env vars must run serially; cargo test
+    // spawns one thread per test, so concurrent set_var/remove_var races.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn translate_sim_spec() {
         let url = translate_spec_to_url("sim::demo").unwrap();
@@ -218,6 +222,7 @@ mod tests {
 
     #[test]
     fn translate_confluence_emits_path_marker() {
+        let _guard = ENV_LOCK.lock().unwrap();
         // Phase 36-followup: the `/confluence/` path marker is what
         // the helper's URL-scheme dispatcher uses to disambiguate
         // between Confluence and JIRA on the shared *.atlassian.net
@@ -237,6 +242,7 @@ mod tests {
 
     #[test]
     fn translate_jira_emits_path_marker() {
+        let _guard = ENV_LOCK.lock().unwrap();
         let saved = std::env::var("REPOSIX_JIRA_INSTANCE").ok();
         std::env::set_var("REPOSIX_JIRA_INSTANCE", "reuben-john");
         let url = translate_spec_to_url("jira::TEST").unwrap();
@@ -252,6 +258,7 @@ mod tests {
 
     #[test]
     fn translate_confluence_requires_tenant() {
+        let _guard = ENV_LOCK.lock().unwrap();
         // Save and clear the env var to ensure this test is deterministic.
         let saved = std::env::var("REPOSIX_CONFLUENCE_TENANT").ok();
         std::env::remove_var("REPOSIX_CONFLUENCE_TENANT");
@@ -267,6 +274,7 @@ mod tests {
 
     #[test]
     fn translate_jira_requires_instance() {
+        let _guard = ENV_LOCK.lock().unwrap();
         let saved = std::env::var("REPOSIX_JIRA_INSTANCE").ok();
         std::env::remove_var("REPOSIX_JIRA_INSTANCE");
         let err = translate_spec_to_url("jira::TEST").unwrap_err();

--- a/crates/reposix-cli/src/sim.rs
+++ b/crates/reposix-cli/src/sim.rs
@@ -113,7 +113,7 @@ impl SimProcess {
         let pid_raw = self.child.id();
         if let Ok(pid_i32) = i32::try_from(pid_raw) {
             if let Some(pid) = rustix::process::Pid::from_raw(pid_i32) {
-                let _ = rustix::process::kill_process(pid, rustix::process::Signal::Term);
+                let _ = rustix::process::kill_process(pid, rustix::process::Signal::TERM);
             }
         }
         let t0 = Instant::now();

--- a/crates/reposix-confluence/Cargo.toml
+++ b/crates/reposix-confluence/Cargo.toml
@@ -28,6 +28,7 @@ chrono = { workspace = true }
 parking_lot = { workspace = true }
 rusqlite = { workspace = true }
 sha2 = { workspace = true }
+hex = { workspace = true }
 url = { workspace = true }
 pulldown-cmark = { workspace = true }
 

--- a/crates/reposix-confluence/src/lib.rs
+++ b/crates/reposix-confluence/src/lib.rs
@@ -1091,7 +1091,7 @@ impl ConfluenceBackend {
         let sha_hex = {
             use sha2::{Digest, Sha256};
             let digest = Sha256::digest(response_bytes);
-            format!("{digest:x}")
+            hex::encode(digest)
         };
         let response_summary = format!("{status}:{}", &sha_hex[..16]);
         let conn = audit.lock();

--- a/crates/reposix-jira/Cargo.toml
+++ b/crates/reposix-jira/Cargo.toml
@@ -28,6 +28,7 @@ chrono = { workspace = true }
 parking_lot = { workspace = true }
 rusqlite = { workspace = true }
 sha2 = { workspace = true }
+hex = { workspace = true }
 serde_yaml = { workspace = true }
 url = { workspace = true }
 

--- a/crates/reposix-jira/src/lib.rs
+++ b/crates/reposix-jira/src/lib.rs
@@ -406,7 +406,7 @@ impl JiraBackend {
         let sha_hex = {
             use sha2::{Digest, Sha256};
             let digest = Sha256::digest(response_bytes);
-            format!("{digest:x}")
+            hex::encode(digest)
         };
         let response_summary = format!("{status}:{}", &sha_hex[..16]);
         let conn = audit.lock();

--- a/crates/reposix-sim/Cargo.toml
+++ b/crates/reposix-sim/Cargo.toml
@@ -38,8 +38,8 @@ parking_lot.workspace = true
 dashmap.workspace = true
 governor.workspace = true
 rusqlite.workspace = true
-sha2 = "0.10"
-hex = "0.4"
+sha2 = "0.11"
+hex = { workspace = true }
 
 [dev-dependencies]
 reqwest.workspace = true

--- a/crates/reposix-swarm/Cargo.toml
+++ b/crates/reposix-swarm/Cargo.toml
@@ -32,7 +32,7 @@ serde_json.workspace = true
 parking_lot.workspace = true
 rusqlite = { workspace = true, features = ["bundled"] }
 hdrhistogram = "7"
-rand = "0.8"
+rand = "0.9"
 async-trait.workspace = true
 chrono.workspace = true
 

--- a/crates/reposix-swarm/src/confluence_direct.rs
+++ b/crates/reposix-swarm/src/confluence_direct.rs
@@ -63,7 +63,7 @@ impl ConfluenceDirectWorkload {
             return None;
         }
         let mut r = self.rng.lock();
-        let idx = r.gen_range(0..ids.len());
+        let idx = r.random_range(0..ids.len());
         Some(ids[idx])
     }
 }

--- a/crates/reposix-swarm/src/sim_direct.rs
+++ b/crates/reposix-swarm/src/sim_direct.rs
@@ -68,7 +68,7 @@ impl SimDirectWorkload {
             return None;
         }
         let mut r = self.rng.lock();
-        let idx = r.gen_range(0..ids.len());
+        let idx = r.random_range(0..ids.len());
         Some(ids[idx])
     }
 }


### PR DESCRIPTION
## Summary

Fixes the three dependabot PRs that failed CI due to breaking API changes:

- **rustix 0.38 → 1.x** (closes #11): `Signal::Term` renamed to `Signal::TERM`
- **rand 0.8 → 0.9** (closes #12): `Rng::gen_range` renamed to `random_range` in `reposix-swarm`
- **sha2 0.10 → 0.11** (closes #14): `Array<u8, …>` no longer implements `LowerHex`; switched to `hex::encode()` (promoted `hex` to a workspace dep — consistent with `reposix-sim` which already used it directly)

All three were combined here because each change to `Cargo.lock` would have conflicted with the others if merged independently.

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] pre-push hook (fmt + clippy) passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
