### PR TITLE
fix(ci): install mkdocs + build reposix-quality before pre-push self-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,24 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - name: Install MkDocs + Material (for pre-push runner gates)
+        # The pre-push self-test (TEST 1 "clean commit passes") drives the
+        # full runner, which composes docs-build/mkdocs-strict +
+        # structure/no-orphan-docs (both shell out to `mkdocs build
+        # --strict`). Mirrors the install in .github/workflows/docs.yml so
+        # the runner sees the same toolchain as a developer's pre-push.
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install mkdocs-material mkdocs-minify-plugin mkdocs-redirects
       - run: cargo test --workspace --locked
+      - name: Build reposix-quality (for docs-alignment/walk gate)
+        # The pre-push runner's docs-alignment/walk row invokes
+        # target/{release,debug}/reposix-quality. `cargo test --workspace`
+        # only ensures *test* binaries; the bin must be built explicitly.
+        run: cargo build -p reposix-quality
       - name: Test pre-push credential hook
         run: bash .githooks/test-pre-push.sh
 

--- a/.gitignore
+++ b/.gitignore
@@ -62,9 +62,13 @@ runtime/bench-*.log
 # Quality Gates runtime artifacts (per-run; regenerate on every runner invocation).
 # .gitkeep placeholders under verifications/ + verdicts/ ARE tracked so the
 # directory tree exists in git; only the per-row JSON + per-run timestamped
-# verdict files are runtime noise. Canonical VERDICT.md per phase IS tracked
-# (QG-06 contract per CLAUDE.md: "the verdict is the contract").
+# verdict files are runtime noise. Canonical VERDICT.md and named evidence
+# artifacts (honesty-spot-check.md, triage.md, verifier-prompt.md, etc.)
+# per phase ARE tracked. The pattern below matches only timestamped runtime
+# snapshots — files whose name starts with a digit (e.g.
+# 2026-04-30T09-07-50Z.md). Renamed pattern from the broader *.md +
+# !VERDICT.md exception to avoid accidentally untracking named evidence
+# (caught in PR #31 cleanup; see commit 4b6f8f3 reversal).
 quality/reports/verifications/*/*.json
-quality/reports/verdicts/*/*.md
-!quality/reports/verdicts/*/VERDICT.md
+quality/reports/verdicts/*/[0-9]*.md
 quality/reports/badge.json

--- a/quality/gates/perf/latency-bench.sh
+++ b/quality/gates/perf/latency-bench.sh
@@ -249,9 +249,15 @@ if [[ -n "${ATLASSIAN_API_KEY:-}" && -n "${ATLASSIAN_EMAIL:-}" \
     CF_AUTH="${ATLASSIAN_EMAIL}:${ATLASSIAN_API_KEY}"
 
     # Warm-up + space-id resolution (matches reposix-confluence/src/lib.rs:1007).
+    # Tolerate HTTP errors here (matches the GH/JIRA warm-up + body-fetch
+    # pattern at lines 191/201/329/340 — a 404/401 from the v2 spaces
+    # endpoint must NOT crash the entire bench under `set -euo pipefail`.
+    # Empty CF_SPACE_ID falls through to the `if [[ -n ]]` guard below
+    # which leaves CF_LIST/GET/PATCH unset; fmt_ms renders those as empty
+    # cells (see line 388 fallback).
     CF_SPACE_ID=$(curl -fsS -u "${CF_AUTH}" \
         "${CF_ORIGIN}/wiki/api/v2/spaces?keys=${CF_PROJECT}" 2>/dev/null \
-        | jq -r '.results[0].id // empty' 2>/dev/null)
+        | jq -r '.results[0].id // empty' 2>/dev/null || echo "")
 
     T0=$(now_ms)
     "${BIN_DIR}/reposix" init "confluence::${CF_PROJECT}" "$CF_REPO" >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary
- The CI `test` job's `Test pre-push credential hook` step runs the full quality-gates runner via `.githooks/test-pre-push.sh`. After fdb4d24 made the pre-push hook propagate runner exit codes, the runner's `docs-build/mkdocs-strict`, `structure/no-orphan-docs`, and `docs-alignment/walk` rows started failing in CI because mkdocs and the `reposix-quality` binary were never installed there.
- This PR mirrors the mkdocs install from `.github/workflows/docs.yml` into the `test` job, plus a `cargo build -p reposix-quality` step before the self-test.
- Local pre-push runner: 22 PASS, 0 FAIL, 3 WAIVED. Walker `last_walked` and `last_verified` timestamps refreshed by the verification re-run.

## Test plan
- [x] Local `python3 quality/runners/run.py --cadence pre-push` exits 0
- [x] Local pre-push hook fires GREEN on push (this branch was pushed cleanly)
- [ ] CI `test` job's `Test pre-push credential hook` step exits 0 on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
