### PR TITLE
refactor(testing): parameterize Confluence space, kill TokenWorld hardcoding

### DIFF
--- a/crates/reposix-cli/tests/agent_flow_real.rs
+++ b/crates/reposix-cli/tests/agent_flow_real.rs
@@ -82,6 +82,13 @@ fn jira_test_project() -> String {
         .unwrap_or_else(|_| "TEST".to_owned())
 }
 
+/// Resolve the Confluence test space key:
+///   `REPOSIX_CONFLUENCE_SPACE`, default `TokenWorld` (historical canonical
+///   per docs/reference/testing-targets.md).
+fn confluence_test_space() -> String {
+    std::env::var("REPOSIX_CONFLUENCE_SPACE").unwrap_or_else(|_| "TokenWorld".to_owned())
+}
+
 /// Run `reposix init <spec> <path>` and assert success + correct
 /// `remote.origin.url` config. Returns the configured URL.
 fn run_init_and_assert(spec: &str, expected_url_prefix: &str) -> String {
@@ -130,7 +137,10 @@ fn dark_factory_real_github() {
     );
 }
 
-/// Confluence `TokenWorld` real-backend init smoke.
+/// Confluence real-backend init smoke. Space is configurable via
+/// `REPOSIX_CONFLUENCE_SPACE` (default `TokenWorld`); mirrors the JIRA
+/// `jira_test_project()` pattern so the test follows whichever space the
+/// configured Atlassian tenant actually owns.
 #[test]
 #[ignore = "real-backend; requires ATLASSIAN_API_KEY/EMAIL/REPOSIX_CONFLUENCE_TENANT"]
 fn dark_factory_real_confluence() {
@@ -140,14 +150,17 @@ fn dark_factory_real_confluence() {
         "REPOSIX_CONFLUENCE_TENANT"
     );
     let tenant = std::env::var("REPOSIX_CONFLUENCE_TENANT").expect("env-presence checked above");
+    let space = confluence_test_space();
     let expected_prefix = format!("reposix::https://{tenant}.atlassian.net/");
-    let url = run_init_and_assert("confluence::TokenWorld", &expected_prefix);
+    let spec = format!("confluence::{space}");
+    let url = run_init_and_assert(&spec, &expected_prefix);
     // Phase 36-followup: the `/confluence/` path marker is required so
     // the helper's URL-scheme dispatcher (crates/reposix-remote/src/
     // backend_dispatch.rs) picks the Confluence backend instead of JIRA.
+    let expected_suffix = format!("/confluence/projects/{space}");
     assert!(
-        url.ends_with("/confluence/projects/TokenWorld"),
-        "url should encode the /confluence/ marker + TokenWorld project, got {url}"
+        url.ends_with(&expected_suffix),
+        "url should encode the /confluence/ marker + space {space}, got {url}"
     );
 }
 

--- a/quality/gates/perf/latency-bench.sh
+++ b/quality/gates/perf/latency-bench.sh
@@ -241,8 +241,8 @@ CF_INIT_MS=""; CF_LIST_MS=""; CF_GET_MS=""; CF_PATCH_MS=""; CF_CAP_MS=""
 CF_N=""; CF_BLOBS=""
 if [[ -n "${ATLASSIAN_API_KEY:-}" && -n "${ATLASSIAN_EMAIL:-}" \
       && -n "${REPOSIX_CONFLUENCE_TENANT:-}" ]]; then
-    echo "latency-bench: Confluence probe — using TokenWorld space" >&2
     CF_PROJECT="${REPOSIX_CONFLUENCE_SPACE:-TokenWorld}"
+    echo "latency-bench: Confluence probe — using ${CF_PROJECT} space" >&2
     CF_REPO="${RUN_DIR}/cf-repo"
     CF_ORIGIN="https://${REPOSIX_CONFLUENCE_TENANT}.atlassian.net"
     export REPOSIX_ALLOWED_ORIGINS="${SIM_URL},${CF_ORIGIN}"
@@ -487,8 +487,9 @@ match.
     that pulled actual blob bytes during the bootstrap fetch.
 [^N]: \`N\` = records returned by the canonical list endpoint:
     sim/github/jira issues, confluence pages in the configured space.
-    **N values reflect live backend state at run time** — the TokenWorld
-    space and \`reubenjohn/reposix\` issue count drift over time; expect
+    **N values reflect live backend state at run time** — the configured
+    Confluence space (\`${CF_PROJECT:-TokenWorld}\`) and \`reubenjohn/reposix\`
+    issue count drift over time; expect
     ±20% wobble between runs. The \`Helper capabilities probe\` row is
     local-only (no network), so it's identical across columns and serves
     as a runner-variance control.
@@ -517,8 +518,8 @@ columns, export the relevant credential bundle before running:
 \`\`\`bash
 # GitHub (reubenjohn/reposix issues)
 export GITHUB_TOKEN=…
-# Confluence (TokenWorld space)
-export ATLASSIAN_API_KEY=… ATLASSIAN_EMAIL=… REPOSIX_CONFLUENCE_TENANT=…
+# Confluence (space key set via REPOSIX_CONFLUENCE_SPACE; default TokenWorld)
+export ATLASSIAN_API_KEY=… ATLASSIAN_EMAIL=… REPOSIX_CONFLUENCE_TENANT=… REPOSIX_CONFLUENCE_SPACE=…
 # JIRA (TEST project, overridable via JIRA_TEST_PROJECT)
 export JIRA_EMAIL=… JIRA_API_TOKEN=… REPOSIX_JIRA_INSTANCE=…
 


### PR DESCRIPTION
## Summary
Parameterize the Confluence space across the bench script and integration test so they follow whatever `REPOSIX_CONFLUENCE_SPACE` points to (default `TokenWorld`) — mirrors the existing `jira_test_project()` pattern.

After the token rotation moved the canonical safe-to-mutate space from `TokenWorld` to `REPOSIX`:
- bench stderr was logging "using TokenWorld space" while actually probing REPOSIX
- shipped `docs/benchmarks/latency.md` footnote + reproducer comment claimed TokenWorld even though the cron now hits REPOSIX
- `dark_factory_real_confluence` test was hardcoded to `confluence::TokenWorld`, so it would have asserted wrong if the assert path ever exercised the API

## Changes
1. `quality/gates/perf/latency-bench.sh:244` — stderr log uses `${CF_PROJECT}`
2. `quality/gates/perf/latency-bench.sh:490` — rendered footnote interpolates `${CF_PROJECT}`
3. `quality/gates/perf/latency-bench.sh:520` — reproducer bash example references the env var
4. `crates/reposix-cli/tests/agent_flow_real.rs` — new `confluence_test_space()` helper (mirror of `jira_test_project()`); test asserts against configured space

## Verification
- Local bench with `REPOSIX_CONFLUENCE_SPACE=REPOSIX`: stderr says "using REPOSIX space"; rendered markdown contains `` Confluence space (`REPOSIX`) ``
- `cargo test -p reposix-cli --test agent_flow_real -- --ignored dark_factory_real_confluence` passes against REPOSIX
- `python3 quality/runners/run.py --cadence pre-push` → 22 PASS, 0 FAIL, 3 WAIVED

🤖 Generated with [Claude Code](https://claude.com/claude-code)
