### PR TITLE
fix(release): stop release-plz stealing latest release pointer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,6 +244,10 @@ Before declaring any user-facing surface shipped (hero copy, install instruction
 
 All invariants are enforced by `scripts/end-state.py` (pre-push hook). When a push is blocked, read the error — it names the violated invariant and the fix. The invariants: no version-pinned filenames, install path leads with package manager, benchmarks in mkdocs nav, no loose ROADMAP/REQUIREMENTS outside `*-phases/`, no orphan docs.
 
+## Release pipeline
+
+**`release-plz.toml`** — `git_release_enable = false` at the workspace level so release-plz does NOT create per-package GitHub releases. Why: each per-package release (zero assets) was published *after* the canonical `v*` release and stole the `releases/latest` pointer, 404'ing the user-facing installer URLs and 3 catalog rows (`release/gh-assets-present`, `install/curl-installer-sh`, `install/powershell-installer-ps1`). Per-package tags and crates.io publishes are unaffected. The canonical multi-platform release lives at `.github/workflows/release.yml` (tag `v*`).
+
 ## Subagent delegation rules
 
 Per the user's global OP #2: "Aggressive subagent delegation." Specifics for this project:

--- a/quality/catalogs/freshness-invariants.json
+++ b/quality/catalogs/freshness-invariants.json
@@ -567,6 +567,37 @@
       "blast_radius": "P0",
       "owner_hint": "if RED: docs-alignment hash drift detected -- run /reposix-quality-refresh <doc> from a fresh top-level Claude session (cannot run from inside /gsd-execute-phase). Stderr names the affected doc.",
       "waiver": null
+    },
+    {
+      "id": "structure/release-plz-disables-gh-releases",
+      "dimension": "structure",
+      "cadence": "pre-push",
+      "kind": "mechanical",
+      "sources": [
+        "release-plz.toml",
+        "CLAUDE.md:release-plz.toml"
+      ],
+      "command": null,
+      "expected": {
+        "asserts": [
+          "release-plz.toml exists at repo root",
+          "release-plz.toml contains a [workspace] table",
+          "release-plz.toml contains 'git_release_enable = false' (per-package GitHub release creation disabled so the canonical v* release stays releases/latest)"
+        ]
+      },
+      "verifier": {
+        "script": "quality/gates/structure/release-plz-config.sh",
+        "args": [],
+        "timeout_s": 10,
+        "container": null
+      },
+      "artifact": "quality/reports/verifications/structure/release-plz-config.json",
+      "status": "PASS",
+      "last_verified": null,
+      "freshness_ttl": null,
+      "blast_radius": "P0",
+      "owner_hint": "if RED: someone deleted release-plz.toml or flipped git_release_enable. The fix is preventive — without it, release-plz creates one zero-asset GH release per workspace package on every push to main, stealing releases/latest from the canonical v* release. See PR #34 (commit f1d89e5) for the original rationale.",
+      "waiver": null
     }
   ]
 }

--- a/quality/gates/structure/release-plz-config.sh
+++ b/quality/gates/structure/release-plz-config.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Release-plz-config verifier.
+#
+# Asserts that release-plz.toml exists and disables per-package GitHub
+# release creation. Without git_release_enable = false, release-plz
+# creates one zero-asset GH release per workspace package on every
+# push to main, stealing releases/latest from the canonical v* release
+# built by .github/workflows/release.yml. That breaks user install
+# URLs (releases/latest/download/reposix-installer.sh) and any catalog
+# row resolving through releases/latest.
+#
+# Bound by:
+#   structure/release-plz-disables-gh-releases
+#
+# Original rationale: PR #34, commit f1d89e5.
+# Exit 0 if all three assertions hold; 1 with diagnostic per miss.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+cfg="release-plz.toml"
+fail=0
+
+if [[ ! -f "$cfg" ]]; then
+  echo "MISSING: $cfg not found at repo root" >&2
+  echo "  recovery: re-add release-plz.toml — see PR #34 commit f1d89e5" >&2
+  exit 1
+fi
+
+if ! grep -qE '^\[workspace\]' "$cfg"; then
+  echo "MISSING: $cfg has no [workspace] table header" >&2
+  echo "  recovery: add '[workspace]' section — see PR #34 commit f1d89e5" >&2
+  fail=1
+fi
+
+if ! grep -qE '^[[:space:]]*git_release_enable[[:space:]]*=[[:space:]]*false' "$cfg"; then
+  echo "MISSING: $cfg does not set 'git_release_enable = false'" >&2
+  echo "  recovery: re-add the line under [workspace] — without it release-plz" >&2
+  echo "  steals releases/latest on every push to main. See PR #34 commit f1d89e5." >&2
+  fail=1
+fi
+
+if [[ $fail -ne 0 ]]; then
+  exit 1
+fi
+
+echo "OK: release-plz.toml disables per-package GH release creation."

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,16 @@
+# release-plz config — see https://release-plz.dev/docs/config
+#
+# We disable GitHub release creation per package because:
+#  1. The canonical multi-platform release at tag `v$VERSION` (built by
+#     `.github/workflows/release.yml`) is the user-facing artifact.
+#  2. release-plz creates per-package releases AFTER the `v*` release,
+#     which steals the `releases/latest` pointer. That breaks user
+#     install URLs (`releases/latest/download/reposix-installer.sh`)
+#     and the catalog rows in quality/catalogs/release-assets.json
+#     that resolve through `releases/latest`.
+#
+# Tag creation stays on (we still need per-package tags for crates.io
+# provenance and git history). Crates.io publishing is unaffected.
+
+[workspace]
+git_release_enable = false


### PR DESCRIPTION
## Summary

Two commits, one durable fix:

**`f1d89e5` — the fix.** `release-plz` was creating one zero-asset GitHub release per workspace package on every push to `main`. Each per-package release published *after* the canonical `v*` multi-platform release and silently moved the `releases/latest` pointer onto a release with no installer assets — 404'ing both user-facing curl/irm install URLs (in `docs/index.md`, `README.md`, tutorials) and 3 catalog rows (`release/gh-assets-present`, `install/curl-installer-sh`, `install/powershell-installer-ps1`). Manual recovery has been `gh release edit v$VERSION --latest` after every release-plz cycle. Adds `release-plz.toml` at repo root with `[workspace] git_release_enable = false`. release-plz keeps publishing to crates.io and creating per-package tags; it just no longer creates GitHub releases. The canonical `v*` release stays the latest by virtue of being the only release left for release-plz to *not* shadow.

**`05efb78` — the invariant.** `release-plz.toml` is now load-bearing: deleting it silently regresses to the broken behavior, and the catalog rows wouldn't catch it until the next real release-plz cycle. Adds a structure-dim verifier (`quality/gates/structure/release-plz-config.sh`, 48 lines, TINY shape) and catalog row (`structure/release-plz-disables-gh-releases`, P0, pre-push cadence) that asserts the file exists with `[workspace]` and `git_release_enable = false`. Pre-push BLOCKs at the offending commit instead of waiting for production breakage.

## Why Option A over Option B

The brief offered two paths: (A) configure release-plz to skip GitHub release creation, or (B) update verifier scripts to ignore `releases/latest` and resolve to the highest-semver `v*` tag explicitly.

Option B is verifier-resilience theater here. The `releases/latest/download/<asset>` URL is not a verifier-only construct — it's hard-coded into every user-facing install command in the project (`docs/index.md`, `README.md`, `docs/tutorials/first-run.md`). Fixing the verifier alone would still leave real users hitting 404s whenever `releases/latest` resolves to a per-package release. Option A fixes both at the source.

The cost of Option A is the loss of per-package GitHub release *pages* — but those pages currently have **zero assets** and just shadow the canonical `v*` page. They're noise, not signal. Per-package **tags** and **crates.io** pages are unaffected (`git_tag_enable` and `publish` are separate fields).

## Validation

**Behavioral A/B test against `release-plz` 0.3.157 dry-run** (run locally in this branch's worktree):

| Config | release-plz plan for `reposix-core 0.12.1` |
|---|---|
| Default (no toml) | `["cargo registry upload", "creation of tag …", "creation of git release"]` |
| Our `git_release_enable = false` | `["cargo registry upload", "creation of tag …"]` |

The "creation of git release" step is **absent** from the plan with the new config — confirmed by parsing release-plz's own dry-run output, not by inference.

**Other checks:**
- Pre-push runner (`python3 quality/runners/run.py --cadence pre-push`): GREEN (23 PASS / 0 FAIL / 0 PARTIAL / 3 WAIVED, exit 0). Includes the new `structure/release-plz-disables-gh-releases` row.
- New verifier exit codes: 0 (positive), 1 (negative test — toml moved aside, expected diagnostic emitted).
- No release.yml, verifier .py, or release-dim catalog change.

## Files changed

- `release-plz.toml` (new, 16 lines) — `[workspace] git_release_enable = false`
- `CLAUDE.md` (+4 lines) — convention note
- `quality/gates/structure/release-plz-config.sh` (new, 48 lines, +x)
- `quality/catalogs/freshness-invariants.json` (+31 lines, one new row)

## Test plan

- [ ] CI green on this branch
- [ ] Merge to main; observe next release-plz cycle (next push to main triggers it)
- [ ] After release-plz runs: confirm GitHub UI still shows `v0.12.0` as Latest (no new per-package releases created)
- [ ] Run `python3 quality/runners/run.py --cadence weekly` against main and confirm the 3 previously-affected rows are PASS
- [ ] Confirm `curl -fsSL https://github.com/reubenjohn/reposix/releases/latest/download/reposix-installer.sh | head` returns the installer (not a 404)
- [ ] Sanity: delete `release-plz.toml` locally → `git commit` → confirm pre-push BLOCKs with the recovery hint, then restore.

## Out of scope

- Cleanup of the 9 existing per-package zero-asset releases for `v0.12.0` — destructive and unnecessary; they age out as new versions ship.
- Any change to the canonical `release.yml` pipeline.
- Any verifier .py change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
