### PR TITLE
fix(release): broaden cargo-binstall-resolves PASS signal beyond one literal string

### DIFF
--- a/.planning/milestones/v0.13.0-phases/GOOD-TO-HAVES.md
+++ b/.planning/milestones/v0.13.0-phases/GOOD-TO-HAVES.md
@@ -1044,3 +1044,19 @@ relief path; cannot be verified statically — no C2 has run since the doctrine 
 **Default disposition:** LOW-MEDIUM — cheap doc fix; fold into the next release-runbook touch.
 
 **STATUS:** OPEN
+
+## 2026-07-07 | Quality gates asserting a third-party tool's exact surface string false-negative when the vendor rewords output | discovered-by: v0.13.0 post-release CI run 28839335746 investigation | severity: LOW-process
+
+**What:** Two gates this release went RED not because the thing they check was broken, but because the verifier's PASS condition grepped a literal, exact surface string from a third-party tool's stdout, and that tool changed its wording between versions: (1) `release/cargo-binstall-resolves` grepped only `github.com/reubenjohn/reposix/releases/download/`, but current cargo-binstall prints `has been downloaded from github.com` on a successful resolve instead of echoing the download URL — the v0.13.0 tag run actually resolved the prebuilt binary in ~1.97s with rc=0, yet the gate FAILed; (2) the p94-badges gate (`quality/gates/docs-build/p94-badges-real-vs-transient.sh`) has the same class of brittleness — asserting an exact badge/response string shape from a third-party service (shields.io or similar) rather than the underlying invariant (badge resolves / is live vs. transient-404).
+
+**Anti-pattern:** quality gates must assert the INVARIANT the row's `expected.asserts` describes (e.g. "resolved a prebuilt binary and exited 0", "badge is live not transiently 404ing"), not a single literal substring lifted from one observed run of a third-party tool's output. Vendor CLI/service wording drifts across versions with no changelog signal to the gate; a single-string match makes every such drift a false-negative RED that looks like a real regression until a human diffs the stdout.
+
+**Fix applied to instance (1) THIS session:** `quality/gates/release/cargo-binstall-resolves.py` PASS logic broadened to a `PASS_SIGNALS` tuple (case-insensitive, accepts both the legacy URL-echo and the newer "has been downloaded from github.com" wording) AND requires the independent "will install the following binaries" line, so a third wording change fails toward PARTIAL/FAIL-investigate rather than silently matching nothing forever. Regression test: `quality/gates/release/test_cargo_binstall_resolves.py`. Catalog row `release/cargo-binstall-resolves` (quality/catalogs/release-assets.json) updated to describe the broadened contract.
+
+**Sketched resolution for the class:** audit all `quality/gates/**/*.py` and `*.sh` verifiers for literal-substring asserts on third-party tool/service stdout or HTTP response bodies (grep for hardcoded URL fragments, exact vendor phrase matches, or single-string `in combined` checks without a fallback signal set); for each hit, either (a) broaden to a small accepted-wordings set with a REGRESSION NOTE like the binstall fix, or (b) switch to a more structural signal (exit code + a documented structural marker) that's less likely to drift. Start with `p94-badges-real-vs-transient.sh` since it's the second instance observed this release.
+
+**Why deferred (this occurrence, instance 2 only):** instance (1) was fixed in-session (< 1h, no new dependency); instance (2) — the p94-badges gate — was only *noticed*, not reproduced or fixed, in this dispatch; fixing it requires reading that gate's current assert logic and the live shields.io/badge-service response shape, which is out of scope for this binstall-focused fix.
+
+**Default disposition:** LOW-process — no correctness bug in the underlying feature either time, but a recurring gate-authoring anti-pattern worth a repo-wide sweep before it produces a third false-negative.
+
+**STATUS:** OPEN

--- a/quality/catalogs/release-assets.json
+++ b/quality/catalogs/release-assets.json
@@ -518,8 +518,9 @@
       "command": "cargo binstall --no-confirm reposix-cli reposix-remote",
       "expected": {
         "asserts": [
-          "in a fresh rust:1.82-slim container with cargo-binstall installed, `cargo binstall --no-confirm --dry-run reposix-cli` resolves to a prebuilt GitHub Release binary (greppable URL match against github.com/reubenjohn/reposix/releases/download/...)",
-          "P90 90-05 (2026-07-04): the historical PARTIAL-acceptable carve-out (P56 SURPRISES.md row 3) is RETIRED -- the pkg-url metadata fix landed pre-P90 (commit 33dd41f, QL-003); PASS is now the expected outcome on the next real container run, not PARTIAL"
+          "in a fresh rust:1.82-slim container with cargo-binstall installed, `cargo binstall --no-confirm --dry-run reposix-cli` resolves to a prebuilt GitHub Release binary: rc==0 AND a 'downloaded from github' signal is present (accepts EITHER the legacy 'github.com/reubenjohn/reposix/releases/download/' URL echo OR cargo-binstall's newer 'has been downloaded from github.com' summary wording, case-insensitive) AND the 'will install the following binaries' line is present",
+          "P90 90-05 (2026-07-04): the historical PARTIAL-acceptable carve-out (P56 SURPRISES.md row 3) is RETIRED -- the pkg-url metadata fix landed pre-P90 (commit 33dd41f, QL-003); PASS is now the expected outcome on the next real container run, not PARTIAL",
+          "post-v0.13.0 (2026-07-07, CI run 28839335746): PASS logic broadened from a single literal-URL substring match to a set of accepted vendor wordings, because cargo-binstall's own stdout wording drifted between versions and false-negatived a genuinely-successful resolve (rc=0, prebuilt binary resolved in ~1.97s). Contract is now invariant-shaped (resolved + will-install-binaries line), not surface-string-shaped; see REGRESSION NOTE in quality/gates/release/cargo-binstall-resolves.py"
         ]
       },
       "verifier": {

--- a/quality/gates/release/cargo-binstall-resolves.py
+++ b/quality/gates/release/cargo-binstall-resolves.py
@@ -3,8 +3,9 @@
 
 Backs catalog row release/cargo-binstall-resolves. Asserts that
 `cargo binstall --no-confirm --dry-run <crate>` resolves to a prebuilt
-GitHub Release binary (greppable URL match against
-github.com/reubenjohn/reposix/releases/download/...).
+GitHub Release binary. PASS asserts the INVARIANT (binstall resolved a
+prebuilt binary and exited 0), not a single fragile vendor-output
+substring — see REGRESSION NOTE at PASS_SIGNALS below.
 
 PARTIAL acceptable per P56 SURPRISES.md row 3: binstall metadata
 mismatch is documented expected state until v0.12.1 MIGRATE-03 lands.
@@ -25,7 +26,28 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[3]
 ARTIFACT_DIR = REPO_ROOT / "quality" / "reports" / "verifications" / "release"
 
-PASS_SIGNAL = "github.com/reubenjohn/reposix/releases/download/"
+# REGRESSION NOTE (2026-07-07, CI run 28839335746): cargo-binstall's stdout
+# wording for "resolved a prebuilt release binary" has changed across
+# versions -- v0.13.0's release gate went RED not because the installer was
+# broken (binstall resolved the real v0.13.0 prebuilt in ~1.97s, rc=0) but
+# because the old verifier grepped ONLY the literal URL substring
+# "github.com/reubenjohn/reposix/releases/download/", and current
+# cargo-binstall prints "has been downloaded from github.com" instead of
+# echoing the full download URL. Asserting a single vendor surface string is
+# brittle by construction -- the next binstall release can reword this
+# again. PASS_SIGNALS below is therefore a set of ACCEPTED wordings
+# (case-insensitive substring match), not a single string. If a FUTURE
+# binstall version reword this a third time, the run will neither match
+# PASS_SIGNALS nor a PARTIAL_SIGNAL and will correctly fall through to
+# FAIL -- when that happens, treat it as "investigate wording drift first",
+# add the new observed wording to PASS_SIGNALS, and only conclude the
+# installer is actually broken if a real 404/no-resolve is present in the
+# combined output.
+PASS_SIGNALS = (
+    "github.com/reubenjohn/reposix/releases/download/",  # binstall <=1.x URL echo
+    "has been downloaded from github.com",  # binstall >=1.y summary wording
+)
+INSTALL_BINARIES_SIGNAL = "will install the following binaries"
 PARTIAL_SIGNALS = (
     "Falling back to source",
     "Falling back to install via 'cargo install'",
@@ -67,52 +89,43 @@ def run_binstall(crate: str, timeout_s: int = 600) -> tuple[int | None, str, str
         return None, out, err, f"timeout after {timeout_s}s"
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser(description="cargo-binstall-resolves verifier")
-    parser.add_argument("--crate", default="reposix-cli")
-    parser.add_argument("--timeout", type=int, default=600)
-    args = parser.parse_args()
+def classify(rc: int | None, combined: str) -> dict:
+    """Pure classification of a completed binstall run into PASS/PARTIAL/FAIL.
 
+    Decoupled from subprocess execution so it can be unit-tested with
+    canned stdout/stderr fixtures (no cargo/cargo-binstall invocation
+    required) — see test_cargo_binstall_resolves.py.
+
+    Returns a dict with keys: status_label, exit_code, asserts_passed,
+    asserts_failed, and (when relevant) matched_signal / fallback_signal.
+    """
     asserts_passed: list[str] = []
     asserts_failed: list[str] = []
-    row_id = "release/cargo-binstall-resolves"
-    fname = "cargo-binstall-resolves.json"
-
-    rc, stdout, stderr, err = run_binstall(args.crate, timeout_s=args.timeout)
-    combined = (stdout or "") + (stderr or "")
-
-    if err:
-        asserts_failed.append(err)
-        write_artifact(fname, {
-            "ts": now_iso(), "row_id": row_id, "crate": args.crate,
-            "returncode": rc, "stdout_excerpt": combined[:2000],
-            "asserts_passed": asserts_passed, "asserts_failed": asserts_failed,
-        })
-        return 1
 
     if "no such command: `binstall`" in combined or "no such command: 'binstall'" in combined:
         asserts_failed.append("cargo-binstall is not installed in the verification environment")
-        write_artifact(fname, {
-            "ts": now_iso(), "row_id": row_id, "crate": args.crate,
-            "returncode": rc, "status_label": "FAIL",
+        return {
+            "status_label": "FAIL", "exit_code": 1,
             "diagnostic": "cargo-binstall not installed",
-            "stdout_excerpt": combined[:2000],
             "asserts_passed": asserts_passed, "asserts_failed": asserts_failed,
-        })
-        return 1
+        }
 
-    if PASS_SIGNAL in combined and rc == 0:
+    combined_lower = combined.lower()
+    pass_signal_hit = next(
+        (s for s in PASS_SIGNALS if s.lower() in combined_lower), None
+    )
+    install_line_hit = INSTALL_BINARIES_SIGNAL.lower() in combined_lower
+
+    if rc == 0 and pass_signal_hit and install_line_hit:
         asserts_passed.append(
-            f"cargo binstall --dry-run {args.crate} resolved prebuilt binary "
-            f"({PASS_SIGNAL}...)"
+            f"cargo binstall --dry-run resolved prebuilt binary "
+            f"(matched signal {pass_signal_hit!r}, install-binaries line present)"
         )
-        write_artifact(fname, {
-            "ts": now_iso(), "row_id": row_id, "crate": args.crate,
-            "returncode": rc, "status_label": "PASS",
-            "stdout_excerpt": combined[:2000],
+        return {
+            "status_label": "PASS", "exit_code": 0,
+            "matched_signal": pass_signal_hit,
             "asserts_passed": asserts_passed, "asserts_failed": asserts_failed,
-        })
-        return 0
+        }
 
     fallback_seen = next((s for s in PARTIAL_SIGNALS if s in combined), None)
     if fallback_seen:
@@ -120,25 +133,48 @@ def main() -> int:
             f"cargo binstall ran (PARTIAL: source-build fallback observed: {fallback_seen!r}); "
             "documented expected state per P56 SURPRISES.md row 3 until MIGRATE-03 v0.12.1"
         )
-        write_artifact(fname, {
-            "ts": now_iso(), "row_id": row_id, "crate": args.crate,
-            "returncode": rc, "status_label": "PARTIAL",
+        return {
+            "status_label": "PARTIAL", "exit_code": 2,
             "fallback_signal": fallback_seen,
-            "stdout_excerpt": combined[:2000],
             "asserts_passed": asserts_passed, "asserts_failed": asserts_failed,
-        })
-        return 2
+        }
 
     asserts_failed.append(
         f"cargo binstall returned {rc} without prebuilt-resolve and without source-fallback signal"
     )
+    return {
+        "status_label": "FAIL", "exit_code": 1,
+        "asserts_passed": asserts_passed, "asserts_failed": asserts_failed,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="cargo-binstall-resolves verifier")
+    parser.add_argument("--crate", default="reposix-cli")
+    parser.add_argument("--timeout", type=int, default=600)
+    args = parser.parse_args()
+
+    row_id = "release/cargo-binstall-resolves"
+    fname = "cargo-binstall-resolves.json"
+
+    rc, stdout, stderr, err = run_binstall(args.crate, timeout_s=args.timeout)
+    combined = (stdout or "") + (stderr or "")
+
+    if err:
+        write_artifact(fname, {
+            "ts": now_iso(), "row_id": row_id, "crate": args.crate,
+            "returncode": rc, "stdout_excerpt": combined[:2000],
+            "asserts_passed": [], "asserts_failed": [err],
+        })
+        return 1
+
+    result = classify(rc, combined)
     write_artifact(fname, {
         "ts": now_iso(), "row_id": row_id, "crate": args.crate,
-        "returncode": rc, "status_label": "FAIL",
-        "stdout_excerpt": combined[:2000],
-        "asserts_passed": asserts_passed, "asserts_failed": asserts_failed,
+        "returncode": rc, "stdout_excerpt": combined[:2000],
+        **{k: v for k, v in result.items() if k != "exit_code"},
     })
-    return 1
+    return result["exit_code"]
 
 
 if __name__ == "__main__":

--- a/quality/gates/release/test_cargo_binstall_resolves.py
+++ b/quality/gates/release/test_cargo_binstall_resolves.py
@@ -1,0 +1,100 @@
+"""quality/gates/release/test_cargo_binstall_resolves.py -- pure-python regression
+test for the release/cargo-binstall-resolves classifier.
+
+Filed to fix CI run 28839335746 (v0.13.0 tag): the gate went RED even though
+cargo-binstall genuinely resolved the v0.13.0 prebuilt binary (rc=0, ~1.97s)
+because the old PASS_SIGNAL grepped only the literal substring
+"github.com/reubenjohn/reposix/releases/download/" and current cargo-binstall
+prints "has been downloaded from github.com" instead. This test feeds BOTH
+wordings (old-URL and new "has been downloaded from") through `classify()`
+and asserts both land on PASS, and separately locks in the PARTIAL
+(source-compile fallback) and FAIL (genuine no-resolve) branches.
+
+Deliberately stdlib+pytest only -- no cargo/cargo-binstall invocation, no
+network. Run: python3 -m pytest quality/gates/release/test_cargo_binstall_resolves.py -x -q
+"""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+_MODULE_PATH = pathlib.Path(__file__).resolve().parent / "cargo-binstall-resolves.py"
+_spec = importlib.util.spec_from_file_location("cargo_binstall_resolves", _MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+cargo_binstall_resolves = importlib.util.module_from_spec(_spec)
+sys.modules["cargo_binstall_resolves"] = cargo_binstall_resolves
+_spec.loader.exec_module(cargo_binstall_resolves)
+
+classify = cargo_binstall_resolves.classify
+
+
+OLD_URL_STDOUT = """\
+INFO resolve: Resolving package: 'reposix-cli'
+INFO downloading from: 'https://github.com/reubenjohn/reposix/releases/download/v0.12.0/reposix-cli-x86_64-unknown-linux-musl.tar.gz'
+INFO This will install the following binaries: reposix => /home/runner/.cargo/bin/reposix
+INFO Done in 1.5s
+"""
+
+NEW_WORDING_STDOUT = """\
+INFO resolve: Resolving package: 'reposix-cli'
+WARN The package reposix-cli v0.13.0 (x86_64-unknown-linux-musl) has been downloaded from github.com
+INFO This will install the following binaries: reposix => /home/runner/.cargo/bin/reposix
+INFO Done in 1.976293126s
+"""
+
+NO_RESOLVE_STDOUT = """\
+INFO resolve: Resolving package: 'reposix-cli'
+ERROR could not find a binstall-compatible release artifact for reposix-cli v0.13.0
+ERROR 404 Not Found
+"""
+
+SOURCE_FALLBACK_STDOUT = """\
+INFO resolve: Resolving package: 'reposix-cli'
+WARN Falling back to source install for reposix-cli
+INFO running `cargo install reposix-cli`
+INFO compiling reposix-cli v0.13.0
+"""
+
+
+def test_old_url_wording_classifies_pass() -> None:
+    result = classify(0, OLD_URL_STDOUT)
+    assert result["status_label"] == "PASS"
+    assert result["exit_code"] == 0
+    assert result["asserts_passed"]
+    assert not result["asserts_failed"]
+
+
+def test_new_downloaded_from_wording_classifies_pass() -> None:
+    """Regression test for CI run 28839335746 -- the exact wording that
+    false-negatived the v0.13.0 post-release gate."""
+    result = classify(0, NEW_WORDING_STDOUT)
+    assert result["status_label"] == "PASS"
+    assert result["exit_code"] == 0
+    assert result["matched_signal"] == "has been downloaded from github.com"
+
+
+def test_genuine_no_resolve_classifies_fail() -> None:
+    result = classify(1, NO_RESOLVE_STDOUT)
+    assert result["status_label"] == "FAIL"
+    assert result["exit_code"] == 1
+    assert result["asserts_failed"]
+
+
+def test_source_compile_fallback_classifies_partial() -> None:
+    result = classify(0, SOURCE_FALLBACK_STDOUT)
+    assert result["status_label"] == "PARTIAL"
+    assert result["exit_code"] == 2
+    assert result["fallback_signal"]
+
+
+def test_rc_nonzero_with_pass_wording_does_not_pass() -> None:
+    """A pass-shaped wording is not enough on its own -- rc must be 0 too."""
+    result = classify(1, NEW_WORDING_STDOUT)
+    assert result["status_label"] != "PASS"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-x", "-q"]))


### PR DESCRIPTION
## Summary
- `release/cargo-binstall-resolves` false-negatived at the v0.13.0 tag (CI run 28839335746) even though cargo-binstall genuinely resolved the prebuilt binary (rc=0, ~1.97s) — the old PASS_SIGNAL grepped only the legacy `github.com/.../releases/download/` URL echo, and current cargo-binstall prints `has been downloaded from github.com` instead.
- Broadens PASS to a case-insensitive accepted-wordings set (`PASS_SIGNALS`) plus an independent "will install the following binaries" check, asserting the resolve invariant rather than one vendor surface string. A REGRESSION NOTE documents the intent so a third wording drift surfaces as investigate-first, not a silent permanent FAIL.
- Adds `quality/gates/release/test_cargo_binstall_resolves.py` (pure-python pytest, no cargo invocation) covering both old and new wordings as PASS, plus the PARTIAL (source fallback) and FAIL (genuine no-resolve) branches.
- Updates the `release/cargo-binstall-resolves` catalog row's `expected.asserts` to describe the broadened contract (status left `NOT-VERIFIED` — no live verdict fabricated).
- Files the anti-pattern (this + `p94-badges-real-vs-transient.sh`) in `.planning/milestones/v0.13.0-phases/GOOD-TO-HAVES.md` for a repo-wide literal-substring-assert sweep.

## Test plan
- [x] `python3 -m pytest quality/gates/release/test_cargo_binstall_resolves.py -x -q` — 5 passed
- [ ] Live `python3 quality/runners/run.py --cadence post-release` re-run — DEFERRED (would invoke cargo-binstall; machine-wide cargo lock held by a concurrent lane during this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
